### PR TITLE
Internal error codes

### DIFF
--- a/webserver/validation.py
+++ b/webserver/validation.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger('pkt.api.validation')
 DEBUG = bool(os.environ.get('PAKET_DEBUG'))
 KWARGS_CHECKERS_AND_FIXERS = {}
 CUSTOM_EXCEPTION_STATUSES = {}
+INTERNAL_ERROR_CODES = {}
 DB_HOST = os.environ.get('PAKET_DB_HOST', '127.0.0.1')
 DB_PORT = int(os.environ.get('PAKET_DB_PORT', 3306))
 DB_USER = os.environ.get('PAKET_DB_USER', 'root')
@@ -231,6 +232,14 @@ CUSTOM_EXCEPTION_STATUSES[InvalidSignature] = 403
 CUSTOM_EXCEPTION_STATUSES[NotImplementedError] = 501
 
 
+INTERNAL_ERROR_CODES[MissingFields] = 100
+INTERNAL_ERROR_CODES[InvalidField] = 101
+INTERNAL_ERROR_CODES[InvalidNonce] = 102
+INTERNAL_ERROR_CODES[InvalidSignature] = 103
+INTERNAL_ERROR_CODES[FingerprintMismatch] = 104
+INTERNAL_ERROR_CODES[DebugOnly] = 121
+
+
 # Since this is a decorator the handler argument will never be None, it is
 # defined as such only to comply with python's syntactic sugar.
 @optional_arg_decorator
@@ -255,7 +264,10 @@ def call(handler=None, required_fields=None, require_auth=None):
                 if DEBUG:
                     response['error']['debug'] = str(exception)
             else:
-                response['error'] = {'message': str(exception), 'error_code': response['status']}
+                response['error'] = {
+                    'message': str(exception),
+                    'error_code': response['status'],
+                    'internal_error_code': INTERNAL_ERROR_CODES.get(type(Exception), default=0)}
         # pylint: enable=broad-except
         if 'error' in response:
             LOGGER.error(response['error'])

--- a/webserver/validation.py
+++ b/webserver/validation.py
@@ -267,7 +267,7 @@ def call(handler=None, required_fields=None, require_auth=None):
                 response['error'] = {
                     'message': str(exception),
                     'error_code': response['status'],
-                    'internal_error_code': INTERNAL_ERROR_CODES.get(type(Exception), default=0)}
+                    'internal_error_code': INTERNAL_ERROR_CODES.get(type(exception), 0)}
         # pylint: enable=broad-except
         if 'error' in response:
             LOGGER.error(response['error'])


### PR DESCRIPTION
First group - errors, that may occur in misuse of our services.
Second group - errors, that may occur on interacting with stellar network
Third group - user-related errors
Forth group - package-related errors

**PAKET - 1**

- 100 - Missing field in request args.
- 101 - Invalid field in request args.
- 102 - Invalid nonce in fingerprint.
- 103 - Invalid signature.
- 104 - Fingerprint does not match call.

- 110 - Geodecoding error

- 120 - Function, only available on testnet, called on main net.
- 121 - Debug mode functionality called when not in debug mode.

**STELLAR - 2**

- 200 - A stellar transaction failed.
- 201 - Stellar account does not exist 
- 202 - Stellar account does not trust BUL
- 204 - Stellar account does not funded.

**FUNDER - 3**

- 300 - Unknown user
- 301 - User already exists
- 302 - User does not provided enough information about himself.
- 303 - User provided invalid phone number.r
- 304 - Specified phone number already in use by another user.

- 310 - User sent invalid or expired verification code.

- 320 - Unable to fund account because fund limit was reached.

**ROUTER - 4**

- 400 - Unknown package